### PR TITLE
DS-972

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /npm-debug.log*
 /testem.log
 /yarn-error.log
+/.vscode
 
 # ember-try
 /.node_modules.ember-try/

--- a/addon/components/htlbid-ad.js
+++ b/addon/components/htlbid-ad.js
@@ -116,6 +116,7 @@ export default Component.extend({
     htlbid.cmd.push(() => {
       htlbid.on('slotRenderEnded', (slot) => {
         if (slot.ref === this.ref) {
+          console.log('Ad rendered', slot) // eslint-disable-line no-console
           if (slot.isEmpty) {
             this._setStatus(true, 0, 0);
           } else {

--- a/addon/components/htlbid-ad.js
+++ b/addon/components/htlbid-ad.js
@@ -122,6 +122,8 @@ export default Component.extend({
             const width = ad.clientWidth;
             const height = ad.clientHeight;
             this._setStatus(false, width, height);
+          } else {
+            this._setStatus(true, 0, 0);
           }
           this.slotRenderEndedAction(slot);
         }

--- a/addon/components/htlbid-ad.js
+++ b/addon/components/htlbid-ad.js
@@ -74,6 +74,19 @@ export default Component.extend({
     @default [false]
     @optional
   */
+
+  clearOnEmptyRefresh: false,
+  /**
+    When set to true, will clear the ad slot when
+    the slot attemps to refresh with a new ad
+    but returns empty.
+
+    @argument clearOnEmptyRefresh
+    @type {Boolean}
+    @default [false]
+    @optional
+  */
+
   isEager: false,
   /**
     Setting isOOP to true specifies that the ad is an "out of page" unit. This is
@@ -116,13 +129,13 @@ export default Component.extend({
     htlbid.cmd.push(() => {
       htlbid.on('slotRenderEnded', (slot) => {
         if (slot.ref === this.ref) {
-          console.log('Ad rendered', slot) // eslint-disable-line no-console
-          if (slot.isEmpty) {
+          if (slot.isEmpty && this.clearOnEmptyRefresh) {
+            htlbid.clear([slot.ref]);
             this._setStatus(true, 0, 0);
-          } else {
+          } else if (!slot.isEmpty) {
             this._setStatus(false, slot.getRenderedWidth(), slot.getRenderedHeight());
           }
-          this.slotRenderEndedAction(event);
+          this.slotRenderEndedAction(slot);
         }
       });
     });

--- a/addon/components/htlbid-ad.js
+++ b/addon/components/htlbid-ad.js
@@ -75,18 +75,6 @@ export default Component.extend({
     @optional
   */
 
-  clearOnEmptyRefresh: false,
-  /**
-    When set to true, will clear the ad slot when
-    the slot attemps to refresh with a new ad
-    but returns empty.
-
-    @argument clearOnEmptyRefresh
-    @type {Boolean}
-    @default [false]
-    @optional
-  */
-
   isEager: false,
   /**
     Setting isOOP to true specifies that the ad is an "out of page" unit. This is
@@ -128,12 +116,12 @@ export default Component.extend({
     this._super(...arguments);
     htlbid.cmd.push(() => {
       htlbid.on('slotRenderEnded', (slot) => {
-        if (slot.ref === this.ref) {
-          if (slot.isEmpty && this.clearOnEmptyRefresh) {
-            htlbid.clear([slot.ref]);
-            this._setStatus(true, 0, 0);
-          } else if (!slot.isEmpty) {
-            this._setStatus(false, slot.getRenderedWidth(), slot.getRenderedHeight());
+        if (slot.ref === this.ref && !slot.isEmpty) {
+          const ad = document.getElementById(slot.id);
+          if (ad) {
+            const width = ad.clientWidth;
+            const height = ad.clientHeight;
+            this._setStatus(false, width, height);
           }
           this.slotRenderEndedAction(slot);
         }


### PR DESCRIPTION
Modifies the code that runs when an ad loads, either on page load of on an ad refresh.
- Removes size updates for empty ads, with the expectation that the current ad will remain.
- Measures ad size with an alternative method suggested by hashtag labs to be more reliable